### PR TITLE
[DPP-02] Added url to printed output line

### DIFF
--- a/dropp.py
+++ b/dropp.py
@@ -49,7 +49,6 @@ if __name__ == '__main__':
 
     # Format the website output to file.
     with open(availability_file_path, 'a') as out_file:
-        out_file.write('\n')
-        out_file.write('\n')
+        out_file.write('\n\n\n')
         for line in availability_list:
-            out_file.write(timestamp() + ' --> ' + line + '\n')
+            out_file.write(timestamp() + '~' + url + '~' + line + '\n\n')


### PR DESCRIPTION
Currently the output file contains only a timestamp and the
availability, unfortunately it is not enough to match an item to its
availability.

This commit adds the url to the output line and formats it so that is
both human-readable and csv-compliant.
